### PR TITLE
마이너 이슈 수정

### DIFF
--- a/app/src/main/java/net/jspiner/epub_viewer/paginator/PagePaginator.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/paginator/PagePaginator.kt
@@ -58,13 +58,13 @@ class PagePaginator(private val context: Context, private val extractedEpub: Epu
         }
     }
     var lastIndex = 0;
-    while (lastIndex != words.length - 1) {
+    while (lastIndex != words.length) {
         var pagingIndex = search(pagingIndex, lastIndex, words.length, 150);
+        if (pagingIndex == words.length - 1) pagingIndex = words.length;
         AndroidFunction.result(pagingIndex);
         lastIndex = pagingIndex;
     }
     AndroidFunction.result(-1);
-
     """.trimIndent()
 
     override fun calculatePage(): Single<PageInfo> {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/base/BaseFragment.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/base/BaseFragment.kt
@@ -8,6 +8,8 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import io.reactivex.subjects.CompletableSubject
+import net.jspiner.epub_viewer.util.LifecycleTransformer
 
 abstract class BaseFragment<Binding: ViewDataBinding, ViewModel: BaseViewModel>: Fragment() {
 
@@ -16,6 +18,8 @@ abstract class BaseFragment<Binding: ViewDataBinding, ViewModel: BaseViewModel>:
 
     protected lateinit var binding: Binding
     protected val viewModel: ViewModel by lazy { (activity as BaseActivity<*, ViewModel>).viewModel }
+
+    private val lifecycleSubject: CompletableSubject by lazy { CompletableSubject.create() }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(
@@ -28,4 +32,14 @@ abstract class BaseFragment<Binding: ViewDataBinding, ViewModel: BaseViewModel>:
     }
 
     protected fun isBindingInitialized() = ::binding.isInitialized
+
+    override fun onDestroy() {
+        super.onDestroy()
+        lifecycleSubject.onComplete()
+    }
+
+    protected fun <T> bindLifecycle(): LifecycleTransformer<T> {
+        return LifecycleTransformer(lifecycleSubject)
+    }
+
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/base/BaseView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/base/BaseView.kt
@@ -7,11 +7,15 @@ import android.support.annotation.LayoutRes
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import io.reactivex.subjects.CompletableSubject
+import net.jspiner.epub_viewer.util.LifecycleTransformer
 import net.jspiner.epub_viewer.util.initLazy
 
 abstract class BaseView<Binding : ViewDataBinding, ViewModel : BaseViewModel> @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val lifecycleSubject: CompletableSubject by lazy { CompletableSubject.create() }
 
     @LayoutRes
     abstract fun getLayoutId(): Int
@@ -33,5 +37,14 @@ abstract class BaseView<Binding : ViewDataBinding, ViewModel : BaseViewModel> @J
     init {
         binding.initLazy()
         viewModel.initLazy()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        lifecycleSubject.onComplete()
+    }
+
+    protected fun <T> bindLifecycle(): LifecycleTransformer<T> {
+        return LifecycleTransformer(lifecycleSubject)
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/etc/EtcActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/etc/EtcActivity.kt
@@ -19,7 +19,7 @@ class EtcActivity : BaseActivity<ActivityEtcBinding, EtcViewModel>() {
 
         val IS_SCROLL_MODE = "keyIsScrollMode"
 
-        fun startActivityForResult(activity: Activity, title: String, author: String, imageFile: File) {
+        fun startActivityForResult(activity: Activity, title: String, author: String, imageFile: File?) {
             val intent = Intent(activity, EtcActivity::class.java)
             intent.putExtra(INTENT_KEY_TITLE, title)
             intent.putExtra(INTENT_KEY_AUTHOR, author)
@@ -30,7 +30,7 @@ class EtcActivity : BaseActivity<ActivityEtcBinding, EtcViewModel>() {
 
     private lateinit var title: String
     private lateinit var author: String
-    private lateinit var imageFile: File
+    private var imageFile: File? = null
 
     override fun getLayoutId() = R.layout.activity_etc
 
@@ -39,7 +39,7 @@ class EtcActivity : BaseActivity<ActivityEtcBinding, EtcViewModel>() {
     override fun loadState(bundle: Bundle) {
         title = bundle.getString(INTENT_KEY_TITLE)!!
         author = bundle.getString(INTENT_KEY_AUTHOR)!!
-        imageFile = bundle.getSerializable(INTENT_KEY_IMAGE_FILE)!! as File
+        imageFile = bundle.getSerializable(INTENT_KEY_IMAGE_FILE) as File?
     }
 
     override fun saveState(bundle: Bundle) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/library/LibraryActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/library/LibraryActivity.kt
@@ -44,6 +44,7 @@ class LibraryActivity : BaseActivity<ActivityLibraryBinding, LibraryViewModel>()
 
         getEpubFilePathList()
             .observeOn(Schedulers.io())
+            .compose(bindLifecycle())
             .subscribe { it -> adapter.setDataList(it) }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -55,6 +55,7 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
         requestPermission()
         viewModel.getViewerType()
             .skip(1)
+            .compose(bindLifecycle())
             .subscribe { calculatePage() }
     }
 
@@ -84,6 +85,7 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
             .doOnSubscribe { showLoading() }
             .doOnComplete { hideLoading() }
             .doOnComplete { calculatePage() }
+            .compose(bindLifecycle<Any>())
             .subscribe()
     }
 
@@ -95,6 +97,7 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe { showLoading() }
             .doOnSuccess { hideLoading() }
+            .compose(bindLifecycle())
             .subscribe()
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -89,9 +89,9 @@ class ReaderViewModel : BaseViewModel() {
 
         val innerPageIndex = index - if (currentSpineIndex == 0) 0 else pageInfo.pageCountSumList[currentSpineIndex - 1]
         val splitIndexList = pageInfo.spinePageList[currentSpineIndex].splitIndexList
-        val splitStart = if (innerPageIndex ==0) 0 else splitIndexList[innerPageIndex -1].toInt() - 1
+        val splitStart = if (innerPageIndex ==0) 0 else splitIndexList[innerPageIndex -1].toInt()
         val splitEnd = splitIndexList[innerPageIndex].toInt()
-        val splitedText =  body.split(" ").subList(splitStart, splitEnd + 1).joinToString(" ")
+        val splitedText =  body.split(" ").subList(splitStart, splitEnd).joinToString(" ")
         val res = String.format(emptyHtml, splitedText)
         rawDataSubject.onNext(originFile to res)
     }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -20,7 +20,6 @@ class ReaderViewModel : BaseViewModel() {
     val extractedEpub: Epub = Epub()
 
     private lateinit var file: File
-    private lateinit var pageInfo: PageInfo
     private val navPointLocationMap: HashMap<String, ItemRef> = HashMap()
 
     private val spineSubject: BehaviorSubject<ItemRef> = BehaviorSubject.create()
@@ -28,6 +27,7 @@ class ReaderViewModel : BaseViewModel() {
     private val toolboxShowSubject: BehaviorSubject<Boolean> = BehaviorSubject.createDefault(true)
     private val pageSubject: BehaviorSubject<Pair<Int, Boolean>> = BehaviorSubject.create()
     private val viewerTypeSubject = BehaviorSubject.createDefault(ViewerType.SCROLL)
+    private val pageInfoSubject = BehaviorSubject.create<PageInfo>()
 
     fun setEpubFile(file: File) {
         this.file = file
@@ -72,6 +72,7 @@ class ReaderViewModel : BaseViewModel() {
     }
 
     private fun sendRawFile(index: Int) {
+        val pageInfo = getCurrentPageInfo()
         var currentSpineIndex = -1
         for ((i, sumUntil) in pageInfo.pageCountSumList.withIndex()) {
             currentSpineIndex = i
@@ -116,7 +117,7 @@ class ReaderViewModel : BaseViewModel() {
         for ((index, item) in extractedEpub.opf.spine.itemrefs.withIndex()) {
             if (item.idRef == itemRef.idRef) {
                 if (index != 0) {
-                    setCurrentPage(pageInfo.pageCountSumList[index - 1], true)
+                    setCurrentPage(getCurrentPageInfo().pageCountSumList[index - 1], true)
                 }
                 else {
                     setCurrentPage(0, true)
@@ -147,11 +148,13 @@ class ReaderViewModel : BaseViewModel() {
     fun getToolboxVisible() = toolboxShowSubject
 
     fun setPageInfo(pageInfo: PageInfo) {
-        this.pageInfo = pageInfo
+        pageInfoSubject.onNext(pageInfo)
         pageSubject.onNext(0 to false)
     }
 
-    fun getPageInfo() = pageInfo
+    fun getCurrentPageInfo() = pageInfoSubject.value!!
+
+    fun getPageInfo(): Observable<PageInfo> = pageInfoSubject
 
     fun getCurrentPage(): Observable<Pair<Int, Boolean>> = pageSubject
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -50,9 +50,7 @@ class ReaderViewModel : BaseViewModel() {
         fun findMatchItemInSpines(content: String): ItemRef {
             for (spineItem in extractedEpub.opf.spine.itemrefs) {
                 val itemFile = toManifestItem(spineItem)
-                val relativePath = itemFile.relativeTo(extractedEpub.extractedDirectory).path
-
-                if (content == relativePath) return spineItem
+                if (content == itemFile.path) return spineItem
             }
             throw RuntimeException("해당 navPoint 를 spine 에서 찾을 수 없음 content : $content")
         }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
@@ -10,6 +10,7 @@ import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.SeekBar
 import android.widget.Toast
+import com.bumptech.glide.Glide
 import io.reactivex.android.schedulers.AndroidSchedulers
 import net.jspiner.animation.AnimationBuilder
 import net.jspiner.epub_viewer.R
@@ -62,11 +63,12 @@ class ToolboxView @JvmOverloads constructor(
         binding.tocBtn.setOnClickListener { showTocPopupMenu() }
         binding.moreButton.setOnClickListener {
             val metaData = viewModel.extractedEpub.opf.metaData
+            val coverImage = metaData.meta?.get("cover")
             EtcActivity.startActivityForResult(
                 getActivity(),
                 metaData.title,
                 metaData.creator?.creator ?: "",
-                viewModel.toManifestItem(metaData.meta?.get("cover")!!)
+                if (coverImage == null) null else viewModel.toManifestItem(coverImage)
             )
         }
         binding.backButton.setOnClickListener { getActivity().finish() }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
@@ -141,7 +141,7 @@ class ToolboxView @JvmOverloads constructor(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { page ->
                 println("page : $page")
-                val pageInfo = viewModel.getPageInfo()
+                val pageInfo = viewModel.getCurrentPageInfo()
 
                 binding.pageDisplay.text = "${page + 1} / ${pageInfo.allPage}"
                 binding.pageSeekbar.max = pageInfo.allPage

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.SeekBar
+import android.widget.Toast
 import io.reactivex.android.schedulers.AndroidSchedulers
 import net.jspiner.animation.AnimationBuilder
 import net.jspiner.epub_viewer.R
@@ -67,6 +68,10 @@ class ToolboxView @JvmOverloads constructor(
                 metaData.creator?.creator ?: "",
                 viewModel.toManifestItem(metaData.meta?.get("cover")!!)
             )
+        }
+        binding.backButton.setOnClickListener { getActivity().finish() }
+        binding.searchButton.setOnClickListener {
+            Toast.makeText(context, "아직 구현되지 않았습니다 :)", Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
@@ -132,6 +132,7 @@ class ToolboxView @JvmOverloads constructor(
 
     private fun subscribe() {
         viewModel.getToolboxVisible()
+            .compose(bindLifecycle())
             .subscribe { isVisible ->
                 if (isVisible) showWindow() else hideWindow()
             }
@@ -139,6 +140,7 @@ class ToolboxView @JvmOverloads constructor(
             .map { it.first } // page
             .distinctUntilChanged()
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe { page ->
                 println("page : $page")
                 val pageInfo = viewModel.getCurrentPageInfo()

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -195,7 +195,7 @@ class EpubView @JvmOverloads constructor(
 
     private fun measureCurrentPage(): Int {
         val currentFragment = adapter.getFragmentAt(binding.verticalViewPager.currentItem)
-        return measureCurrentPage(currentFragment.getScrollPosition().value!!)
+        return measureCurrentPage(currentFragment.getScrollPosition().value ?: 0)
     }
 
     private fun measureCurrentPage(scrollPosition:Int): Int {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -43,16 +43,19 @@ class EpubView @JvmOverloads constructor(
         viewModel.getCurrentSpineItem()
             .map { viewModel.toManifestItem(it) }
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe { setSpineFile(it) }
 
         viewModel.getRawData()
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe { setRawData(it.first.toURI().toURL().toString(), it.second) }
 
         viewModel.getCurrentPage()
             .filter { it.second } // needUpdate
             .map { it.first } // page
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe { setCurrentPage(it) }
 
         Observable.zip(
@@ -60,6 +63,7 @@ class EpubView @JvmOverloads constructor(
             viewModel.getViewerType(),
             BiFunction { _: PageInfo, t2 : ViewerType -> t2 }
         ).observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe { viewerType ->
                 val pageInfo = viewModel.getCurrentPageInfo()
                 when(viewerType) {
@@ -71,6 +75,7 @@ class EpubView @JvmOverloads constructor(
 
         viewModel.getViewerType()
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindLifecycle())
             .subscribe {
                 when(it!!) {
                     ViewerType.SCROLL -> binding.verticalViewPager.verticalMode()

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -11,6 +11,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import net.jspiner.epub_viewer.R
 import net.jspiner.epub_viewer.databinding.ViewEpubViewerBinding
+import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.dto.ViewerType
 import net.jspiner.epub_viewer.ui.base.BaseView
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
@@ -54,17 +55,18 @@ class EpubView @JvmOverloads constructor(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { setCurrentPage(it) }
 
-        Observable.combineLatest(
-            viewModel.getCurrentPage().take(1),
+        Observable.zip(
+            viewModel.getPageInfo(),
             viewModel.getViewerType(),
-            BiFunction { _: Pair<Int, Boolean>, t2 : ViewerType -> t2 }
+            BiFunction { _: PageInfo, t2 : ViewerType -> t2 }
         ).observeOn(AndroidSchedulers.mainThread())
             .subscribe { viewerType ->
-                val pageInfo = viewModel.getPageInfo()
+                val pageInfo = viewModel.getCurrentPageInfo()
                 when(viewerType) {
                     ViewerType.SCROLL -> adapter.setAllPageCount(pageInfo.spinePageList.size)
                     ViewerType.PAGE -> adapter.setAllPageCount(pageInfo.allPage)
                 }
+                binding.verticalViewPager.currentItem = 0
             }
 
         viewModel.getViewerType()
@@ -103,13 +105,13 @@ class EpubView @JvmOverloads constructor(
             return if (index == 0) {
                 0
             } else {
-                (currentPage - viewModel.getPageInfo().pageCountSumList[index - 1]) * deviceHeight
+                (currentPage - viewModel.getCurrentPageInfo().pageCountSumList[index - 1]) * deviceHeight
             }
         }
 
         var spineIndex = -1
         var scrollPosition = 0
-        for ((i, pageSum) in viewModel.getPageInfo().pageCountSumList.withIndex()) {
+        for ((i, pageSum) in viewModel.getCurrentPageInfo().pageCountSumList.withIndex()) {
             if (currentPage + 1 <= pageSum) {
                 spineIndex = i
                 scrollPosition = getScrollPosition(i)
@@ -188,7 +190,7 @@ class EpubView @JvmOverloads constructor(
     private fun onScrollToPrevSpine(fragment: WebContainerFragment, position: Int) {
         if (viewModel.getCurrentViewerType() == ViewerType.SCROLL) {
             fragment.scrollAfterLoading(
-                viewModel.getPageInfo().spinePageList[position].height.toInt()
+                viewModel.getCurrentPageInfo().spinePageList[position].height.toInt()
             )
         }
     }
@@ -201,7 +203,7 @@ class EpubView @JvmOverloads constructor(
     private fun measureCurrentPage(scrollPosition:Int): Int {
         return if (viewModel.getCurrentViewerType() == ViewerType.SCROLL) {
             val spinePosition = binding.verticalViewPager.currentItem
-            val pageInfo = viewModel.getPageInfo()
+            val pageInfo = viewModel.getCurrentPageInfo()
             val deviceHeight = context.resources.displayMetrics.heightPixels
 
             val sumUntilPreview = if (spinePosition == 0) 0 else pageInfo.pageCountSumList[spinePosition - 1]

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
@@ -18,7 +18,7 @@ class WebContainerFragment: BaseFragment<FragmentWebContainerBinding, ReaderView
     private val CONTENT_CLEAR_URL = "about:blank"
 
     private var scrollStatusSubject = BehaviorSubject.createDefault(ScrollStatus.REACHED_TOP)
-    private var scrollPositionSubject = BehaviorSubject.createDefault(0)
+    private var scrollPositionSubject = BehaviorSubject.create<Int>()
     private val epubWebClient by lazy { EpubWebClient(pageFinishCallback) }
 
     companion object {
@@ -42,6 +42,8 @@ class WebContainerFragment: BaseFragment<FragmentWebContainerBinding, ReaderView
         binding.webView.let { webView ->
             fun getContentHeight() = (webView.contentHeight * resources.displayMetrics.density.toDouble()).toInt()
             fun updateScrollState() {
+                if (!epubWebClient.isPageFinished || epubWebClient.scrollPositionAfterLoading != 0) return
+
                 val height = getContentHeight()
                 val webViewHeight = webView.measuredHeight
 
@@ -119,5 +121,6 @@ class WebContainerFragment: BaseFragment<FragmentWebContainerBinding, ReaderView
         if (url != CONTENT_CLEAR_URL) {
             binding.loadingView.visibility = GONE
         }
+        if (epubWebClient.scrollPositionAfterLoading == 0 && binding.webView.scrollY == 0) scrollPositionSubject.onNext(0)
     }
 }


### PR DESCRIPTION
## 개요
- 앱을 테스트하면서 발생한 마이너 이슈들을 수정하였습니다.

## 작업내용
- manifest / toc에서 절대주소, 상대주소가 혼용된 이슈
- slider로 페이지 이동시 해당 spine의 첫번째 페이지로 이동한뒤 해당페이지로 이동하는 이슈
- rxjava subscribe후 lifecycle에 binding이 안된문제
- 넘겨보기(페이지로 보기) 방식에서 마지막 단어가 짤리는 이슈
- toolbox에 아무동작하지 않는 버튼
- coverimage 가 없는 경우 추가
