### PR TITLE
MVVM 코드정리, type별 코드 분할

### DIFF
--- a/app/src/main/java/net/jspiner/epub_viewer/dto/LoadData.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/dto/LoadData.kt
@@ -1,0 +1,14 @@
+package net.jspiner.epub_viewer.dto
+
+import java.io.File
+
+data class LoadData(
+    val loadType: LoadType,
+    val file: File,
+    val rawData: String? = null
+)
+
+enum class LoadType {
+    RAW,
+    FILE
+}

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -92,7 +92,7 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
     private fun calculatePage() {
         getPaginator(baseContext, viewModel.extractedEpub).calculatePage()
             .doOnSuccess { viewModel.setPageInfo(it) }
-            .doOnSuccess { viewModel.navigateToIndex(0) }
+            .doOnSuccess { viewModel.onPagerItemSelected(0) }
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe { showLoading() }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -92,7 +92,6 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
     private fun calculatePage() {
         getPaginator(baseContext, viewModel.extractedEpub).calculatePage()
             .doOnSuccess { viewModel.setPageInfo(it) }
-            .doOnSuccess { viewModel.onPagerItemSelected(0) }
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe { showLoading() }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -31,7 +31,7 @@ class ReaderViewModel : BaseViewModel() {
 
     private val loadDataSubject: PublishSubject<LoadData> = PublishSubject.create()
     private val toolboxShowSubject: BehaviorSubject<Boolean> = BehaviorSubject.createDefault(true)
-    private val pageSubject: BehaviorSubject<Pair<Int, Boolean>> = BehaviorSubject.create()
+    private val pageSubject: PublishSubject<Pair<Int, Boolean>> = PublishSubject.create()
     private val viewerTypeSubject = BehaviorSubject.createDefault(ViewerType.SCROLL)
     private val pageInfoSubject = BehaviorSubject.create<PageInfo>()
 
@@ -67,12 +67,6 @@ class ReaderViewModel : BaseViewModel() {
             navPointLocationMap[navPoint.id] = findMatchItemInSpines(navPointContent)
         }
     }
-
-    fun setLoadData(loadData: LoadData) {
-        loadDataSubject.onNext(loadData)
-    }
-
-    fun getLoadData(): Observable<LoadData> = loadDataSubject
 
     fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         viewerTypeStrategy.onPagerItemSelected(
@@ -112,29 +106,23 @@ class ReaderViewModel : BaseViewModel() {
         throw RuntimeException("해당 itemRef 를 manifest 에서 찾을 수 없음 id : $id")
     }
 
+    fun getToolboxVisible(): Observable<Boolean> = toolboxShowSubject
+    fun getCurrentToolboxVisible() = toolboxShowSubject.value!!
     fun setToolboxVisible(isVisible: Boolean) = toolboxShowSubject.onNext(isVisible)
-
-    fun getToolboxVisible() = toolboxShowSubject
 
     fun setPageInfo(pageInfo: PageInfo) {
         pageInfoSubject.onNext(pageInfo)
         pageSubject.onNext(0 to false)
     }
 
+    fun getPageInfo(): Observable<PageInfo> = pageInfoSubject
     fun getCurrentPageInfo() = pageInfoSubject.value!!
 
-    fun getPageInfo(): Observable<PageInfo> = pageInfoSubject
-
     fun getCurrentPage(): Observable<Pair<Int, Boolean>> = pageSubject
-
-    fun setCurrentPage(page: Int, needUpdate: Boolean) {
-        pageSubject.onNext(page to needUpdate)
-    }
+    fun setCurrentPage(page: Int, needUpdate: Boolean) = pageSubject.onNext(page to needUpdate)
 
     fun getViewerType(): Observable<ViewerType> = viewerTypeSubject
-
     fun getCurrentViewerType() = viewerTypeSubject.value
-
     fun setViewerType(viewerType: ViewerType) {
         viewerTypeSubject.onNext(viewerType)
 
@@ -143,5 +131,8 @@ class ReaderViewModel : BaseViewModel() {
             ViewerType.PAGE -> PageTypeStrategy(this)
         }
     }
+
+    fun getLoadData(): Observable<LoadData> = loadDataSubject
+    fun setLoadData(loadData: LoadData) = loadDataSubject.onNext(loadData)
 
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -5,6 +5,7 @@ import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import net.jspiner.epub_viewer.dto.Epub
+import net.jspiner.epub_viewer.dto.LoadData
 import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.dto.ViewerType
 import net.jspiner.epub_viewer.ui.base.BaseViewModel
@@ -16,9 +17,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epubstream.EpubStream
 import net.jspiner.epubstream.dto.ItemRef
 import net.jspiner.epubstream.dto.NavPoint
-import java.io.BufferedReader
 import java.io.File
-import java.io.FileReader
 
 class ReaderViewModel : BaseViewModel() {
 
@@ -30,8 +29,7 @@ class ReaderViewModel : BaseViewModel() {
     private lateinit var file: File
     private val navPointLocationMap: HashMap<String, ItemRef> = HashMap()
 
-    private val spineSubject: BehaviorSubject<ItemRef> = BehaviorSubject.create()
-    private val rawDataSubject = PublishSubject.create<Pair<File, String>>()
+    private val loadDataSubject: PublishSubject<LoadData> = PublishSubject.create()
     private val toolboxShowSubject: BehaviorSubject<Boolean> = BehaviorSubject.createDefault(true)
     private val pageSubject: BehaviorSubject<Pair<Int, Boolean>> = BehaviorSubject.create()
     private val viewerTypeSubject = BehaviorSubject.createDefault(ViewerType.SCROLL)
@@ -70,11 +68,11 @@ class ReaderViewModel : BaseViewModel() {
         }
     }
 
-    fun setSpineItem(itemRef: ItemRef) {
-        spineSubject.onNext(itemRef)
+    fun setLoadData(loadData: LoadData) {
+        loadDataSubject.onNext(loadData)
     }
 
-    fun getCurrentSpineItem(): Observable<ItemRef> = spineSubject
+    fun getLoadData(): Observable<LoadData> = loadDataSubject
 
     fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         viewerTypeStrategy.onPagerItemSelected(
@@ -146,9 +144,4 @@ class ReaderViewModel : BaseViewModel() {
         }
     }
 
-    fun getRawData(): Observable<Pair<File, String>> = rawDataSubject
-
-    fun setRawData(dataPair: Pair<File, String>) {
-        rawDataSubject.onNext(dataPair)
-    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -11,6 +11,8 @@ import net.jspiner.epub_viewer.ui.base.BaseViewModel
 import net.jspiner.epub_viewer.ui.reader.strategy.PageTypeStrategy
 import net.jspiner.epub_viewer.ui.reader.strategy.ScrollTypeStrategy
 import net.jspiner.epub_viewer.ui.reader.strategy.ViewerTypeStrategy
+import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
+import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epubstream.EpubStream
 import net.jspiner.epubstream.dto.ItemRef
 import net.jspiner.epubstream.dto.NavPoint
@@ -70,10 +72,13 @@ class ReaderViewModel : BaseViewModel() {
 
     fun getCurrentSpineItem(): Observable<ItemRef> = spineSubject
 
-    fun navigateToIndex(index: Int) {
+    fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
+        viewerTypeStrategy.onPagerItemSelected(
+            pager, adapter, position
+        )
         when (getCurrentViewerType()!!) {
-            ViewerType.SCROLL -> spineSubject.onNext(extractedEpub.opf.spine.itemrefs[index])
-            ViewerType.PAGE -> sendRawFile(index)
+            ViewerType.SCROLL -> spineSubject.onNext(extractedEpub.opf.spine.itemrefs[position])
+            ViewerType.PAGE -> sendRawFile(position)
         }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -8,6 +8,9 @@ import net.jspiner.epub_viewer.dto.Epub
 import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.dto.ViewerType
 import net.jspiner.epub_viewer.ui.base.BaseViewModel
+import net.jspiner.epub_viewer.ui.reader.strategy.PageTypeStrategy
+import net.jspiner.epub_viewer.ui.reader.strategy.ScrollTypeStrategy
+import net.jspiner.epub_viewer.ui.reader.strategy.ViewerTypeStrategy
 import net.jspiner.epubstream.EpubStream
 import net.jspiner.epubstream.dto.ItemRef
 import net.jspiner.epubstream.dto.NavPoint
@@ -16,6 +19,9 @@ import java.io.File
 import java.io.FileReader
 
 class ReaderViewModel : BaseViewModel() {
+
+    var viewerTypeStrategy: ViewerTypeStrategy = ScrollTypeStrategy()
+        private set
 
     val extractedEpub: Epub = Epub()
 
@@ -167,6 +173,11 @@ class ReaderViewModel : BaseViewModel() {
 
     fun setViewerType(viewerType: ViewerType) {
         viewerTypeSubject.onNext(viewerType)
+
+        viewerTypeStrategy = when(viewerType) {
+            ViewerType.SCROLL -> ScrollTypeStrategy()
+            ViewerType.PAGE -> PageTypeStrategy()
+        }
     }
 
     fun getRawData(): Observable<Pair<File, String>> = rawDataSubject

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -20,7 +20,7 @@ import java.io.FileReader
 
 class ReaderViewModel : BaseViewModel() {
 
-    var viewerTypeStrategy: ViewerTypeStrategy = ScrollTypeStrategy()
+    var viewerTypeStrategy: ViewerTypeStrategy = ScrollTypeStrategy(this)
         private set
 
     val extractedEpub: Epub = Epub()
@@ -175,8 +175,8 @@ class ReaderViewModel : BaseViewModel() {
         viewerTypeSubject.onNext(viewerType)
 
         viewerTypeStrategy = when(viewerType) {
-            ViewerType.SCROLL -> ScrollTypeStrategy()
-            ViewerType.PAGE -> PageTypeStrategy()
+            ViewerType.SCROLL -> ScrollTypeStrategy(this)
+            ViewerType.PAGE -> PageTypeStrategy(this)
         }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,0 +1,5 @@
+package net.jspiner.epub_viewer.ui.reader.strategy
+
+class PageTypeStrategy : ViewerTypeStrategy {
+
+}

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,5 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import net.jspiner.epub_viewer.dto.LoadData
+import net.jspiner.epub_viewer.dto.LoadType
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
@@ -46,7 +48,13 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
         val splitEnd = splitIndexList[innerPageIndex].toInt()
         val splitedText = body.split(" ").subList(splitStart, splitEnd).joinToString(" ")
         val res = String.format(emptyHtml, splitedText)
-        viewModel.setRawData(originFile to res)
+        viewModel.setLoadData(
+            LoadData(
+                LoadType.RAW,
+                originFile,
+                res
+            )
+        )
     }
 
     private fun readFile(file: File): String {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -6,7 +6,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-class PageTypeStrategy : ViewerTypeStrategy() {
+class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewModel) {
 
     override fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager) {
         verticalViewPager.horizontalMode()

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -4,6 +4,7 @@ import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
+import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 class PageTypeStrategy : ViewerTypeStrategy {
 
@@ -23,6 +24,10 @@ class PageTypeStrategy : ViewerTypeStrategy {
     }
 
     override fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int) {
+        // no-op
+    }
+
+    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int) {
         // no-op
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -6,7 +6,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-class PageTypeStrategy : ViewerTypeStrategy {
+class PageTypeStrategy : ViewerTypeStrategy() {
 
     override fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager) {
         verticalViewPager.horizontalMode()

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -3,7 +3,6 @@ package net.jspiner.epub_viewer.ui.reader.strategy
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
-import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewModel) {
 
@@ -15,14 +14,6 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
 
     override fun setCurrentPagerItem(pager: VerticalViewPager, adapter: EpubPagerAdapter, currentPage: Int) {
         pager.currentItem = currentPage
-    }
-
-    override fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int) {
-        // no-op
-    }
-
-    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
-        // no-op
     }
 
     override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,6 +1,5 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
-import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
@@ -12,31 +11,21 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
         verticalViewPager.horizontalMode()
     }
 
-    override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.allPage
+    override fun getAllPageCount(): Int = pageInfo.allPage
 
-    override fun setCurrentPagerItem(
-        pager: VerticalViewPager,
-        adapter: EpubPagerAdapter,
-        pageInfo: PageInfo,
-        currentPage: Int
-    ) {
+    override fun setCurrentPagerItem(pager: VerticalViewPager, adapter: EpubPagerAdapter, currentPage: Int) {
         pager.currentItem = currentPage
     }
 
-    override fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int) {
+    override fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int) {
         // no-op
     }
 
-    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int) {
+    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
         // no-op
     }
 
-    override fun onPagerItemSelected(
-        viewModel: ReaderViewModel,
-        pager: VerticalViewPager,
-        adapter: EpubPagerAdapter,
-        position: Int
-    ) {
+    override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         viewModel.setCurrentPage(position, false)
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -30,4 +30,13 @@ class PageTypeStrategy : ViewerTypeStrategy {
     override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int) {
         // no-op
     }
+
+    override fun onPagerItemSelected(
+        viewModel: ReaderViewModel,
+        pager: VerticalViewPager,
+        adapter: EpubPagerAdapter,
+        position: Int
+    ) {
+        viewModel.setCurrentPage(position, false)
+    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,5 +1,9 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import net.jspiner.epub_viewer.dto.PageInfo
+
 class PageTypeStrategy : ViewerTypeStrategy {
+
+    override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.allPage
 
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,8 +1,13 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 class PageTypeStrategy : ViewerTypeStrategy {
+
+    override fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager) {
+        verticalViewPager.horizontalMode()
+    }
 
     override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.allPage
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 class PageTypeStrategy : ViewerTypeStrategy {
@@ -11,4 +12,12 @@ class PageTypeStrategy : ViewerTypeStrategy {
 
     override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.allPage
 
+    override fun setCurrentPagerItem(
+        pager: VerticalViewPager,
+        adapter: EpubPagerAdapter,
+        pageInfo: PageInfo,
+        currentPage: Int
+    ) {
+        pager.currentItem = currentPage
+    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -3,6 +3,9 @@ package net.jspiner.epub_viewer.ui.reader.strategy
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileReader
 
 class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewModel) {
 
@@ -18,5 +21,45 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
 
     override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         viewModel.setCurrentPage(position, false)
+
+        sendRawFile(position)
+    }
+
+    private fun sendRawFile(index: Int) {
+        var currentSpineIndex = -1
+        for ((i, sumUntil) in pageInfo.pageCountSumList.withIndex()) {
+            currentSpineIndex = i
+            if (index < sumUntil) break
+        }
+
+        val originFile = viewModel.toManifestItem(viewModel.extractedEpub.opf.spine.itemrefs[currentSpineIndex])
+        val rawString = readFile(originFile)
+        val bodyStart = rawString.indexOf("<body>") + "<body>".length
+        val bodyEnd = rawString.indexOf("</body")
+
+        val emptyHtml = rawString.substring(0, bodyStart) + "%s" + rawString.substring(bodyEnd)
+        val body = rawString.substring(bodyStart, bodyEnd)
+
+        val innerPageIndex = index - if (currentSpineIndex == 0) 0 else pageInfo.pageCountSumList[currentSpineIndex - 1]
+        val splitIndexList = pageInfo.spinePageList[currentSpineIndex].splitIndexList
+        val splitStart = if (innerPageIndex == 0) 0 else splitIndexList[innerPageIndex - 1].toInt()
+        val splitEnd = splitIndexList[innerPageIndex].toInt()
+        val splitedText = body.split(" ").subList(splitStart, splitEnd).joinToString(" ")
+        val res = String.format(emptyHtml, splitedText)
+        viewModel.setRawData(originFile to res)
+    }
+
+    private fun readFile(file: File): String {
+        return BufferedReader(FileReader(file)).use { br ->
+            val sb = StringBuilder()
+            var line = br.readLine()
+
+            while (line != null) {
+                sb.append(line)
+                sb.append(System.lineSeparator())
+                line = br.readLine()
+            }
+            sb.toString()
+        }
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
@@ -19,5 +20,9 @@ class PageTypeStrategy : ViewerTypeStrategy {
         currentPage: Int
     ) {
         pager.currentItem = currentPage
+    }
+
+    override fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int) {
+        // no-op
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 class ScrollTypeStrategy : ViewerTypeStrategy {
@@ -11,4 +12,33 @@ class ScrollTypeStrategy : ViewerTypeStrategy {
 
     override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.spinePageList.size
 
+    override fun setCurrentPagerItem(
+        pager: VerticalViewPager,
+        adapter: EpubPagerAdapter,
+        pageInfo: PageInfo,
+        currentPage: Int
+    ) {
+        fun getScrollPosition(index: Int): Int {
+            val deviceHeight = pager.context.resources.displayMetrics.heightPixels
+
+            return if (index == 0) {
+                0
+            } else {
+                (currentPage - pageInfo.pageCountSumList[index - 1]) * deviceHeight
+            }
+        }
+
+        var spineIndex = -1
+        var scrollPosition = 0
+        for ((i, pageSum) in pageInfo.pageCountSumList.withIndex()) {
+            if (currentPage + 1 <= pageSum) {
+                spineIndex = i
+                scrollPosition = getScrollPosition(i)
+                break
+            }
+        }
+
+        pager.currentItem = spineIndex
+        adapter.getFragmentAt(spineIndex).scrollAfterLoading(scrollPosition)
+    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -1,5 +1,9 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import net.jspiner.epub_viewer.dto.PageInfo
+
 class ScrollTypeStrategy : ViewerTypeStrategy {
+
+    override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.spinePageList.size
 
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -1,0 +1,5 @@
+package net.jspiner.epub_viewer.ui.reader.strategy
+
+class ScrollTypeStrategy : ViewerTypeStrategy {
+
+}

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -1,8 +1,13 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 class ScrollTypeStrategy : ViewerTypeStrategy {
+
+    override fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager) {
+        verticalViewPager.verticalMode()
+    }
 
     override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.spinePageList.size
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -50,6 +50,8 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
 
         if (lastSpineIndex == position + 1) onScrollToPrevPagerItem(currentFragment, position)
         lastSpineIndex = position
+
+        viewModel.setSpineItem(viewModel.extractedEpub.opf.spine.itemrefs[position])
     }
     
     private fun subscribeScroll(fragment: WebContainerFragment, pager: VerticalViewPager) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -44,23 +44,6 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         adapter.getFragmentAt(spineIndex).scrollAfterLoading(scrollPosition)
     }
 
-    override fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int) {
-        val spinePosition = pager.currentItem
-        val pageInfo = viewModel.getCurrentPageInfo()
-        val deviceHeight = pager.context.resources.displayMetrics.heightPixels
-
-        val sumUntilPreview = if (spinePosition == 0) 0 else pageInfo.pageCountSumList[spinePosition - 1]
-
-        val measuredPage =sumUntilPreview + (scrollPosition / deviceHeight)
-        viewModel.setCurrentPage(measuredPage, false)
-    }
-
-    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
-        fragment.scrollAfterLoading(
-            pageInfo.spinePageList[position].height.toInt()
-        )
-    }
-
     override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         val currentFragment = adapter.getFragmentAt(position)
         subscribeScroll(currentFragment, pager)
@@ -93,5 +76,22 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
                     scrollPosition
                 )
             }.let { lastScrollDisposables.add(it) }
+    }
+
+    private fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int) {
+        val spinePosition = pager.currentItem
+        val pageInfo = viewModel.getCurrentPageInfo()
+        val deviceHeight = pager.context.resources.displayMetrics.heightPixels
+
+        val sumUntilPreview = if (spinePosition == 0) 0 else pageInfo.pageCountSumList[spinePosition - 1]
+
+        val measuredPage =sumUntilPreview + (scrollPosition / deviceHeight)
+        viewModel.setCurrentPage(measuredPage, false)
+    }
+
+    private fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
+        fragment.scrollAfterLoading(
+            pageInfo.spinePageList[position].height.toInt()
+        )
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
@@ -40,5 +41,16 @@ class ScrollTypeStrategy : ViewerTypeStrategy {
 
         pager.currentItem = spineIndex
         adapter.getFragmentAt(spineIndex).scrollAfterLoading(scrollPosition)
+    }
+
+    override fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int) {
+        val spinePosition = pager.currentItem
+        val pageInfo = viewModel.getCurrentPageInfo()
+        val deviceHeight = pager.context.resources.displayMetrics.heightPixels
+
+        val sumUntilPreview = if (spinePosition == 0) 0 else pageInfo.pageCountSumList[spinePosition - 1]
+
+        val measuredPage =sumUntilPreview + (scrollPosition / deviceHeight)
+        viewModel.setCurrentPage(measuredPage, false)
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -4,6 +4,7 @@ import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
+import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 class ScrollTypeStrategy : ViewerTypeStrategy {
 
@@ -52,5 +53,11 @@ class ScrollTypeStrategy : ViewerTypeStrategy {
 
         val measuredPage =sumUntilPreview + (scrollPosition / deviceHeight)
         viewModel.setCurrentPage(measuredPage, false)
+    }
+
+    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int) {
+        fragment.scrollAfterLoading(
+            currentPageInfo.spinePageList[position].height.toInt()
+        )
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -2,7 +2,6 @@ package net.jspiner.epub_viewer.ui.reader.strategy
 
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.ScrollStatus
@@ -18,14 +17,9 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         verticalViewPager.verticalMode()
     }
 
-    override fun getAllPageCount(pageInfo: PageInfo) = pageInfo.spinePageList.size
+    override fun getAllPageCount(): Int = pageInfo.spinePageList.size
 
-    override fun setCurrentPagerItem(
-        pager: VerticalViewPager,
-        adapter: EpubPagerAdapter,
-        pageInfo: PageInfo,
-        currentPage: Int
-    ) {
+    override fun setCurrentPagerItem(pager: VerticalViewPager, adapter: EpubPagerAdapter, currentPage: Int) {
         fun getScrollPosition(index: Int): Int {
             val deviceHeight = pager.context.resources.displayMetrics.heightPixels
 
@@ -50,7 +44,7 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         adapter.getFragmentAt(spineIndex).scrollAfterLoading(scrollPosition)
     }
 
-    override fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int) {
+    override fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int) {
         val spinePosition = pager.currentItem
         val pageInfo = viewModel.getCurrentPageInfo()
         val deviceHeight = pager.context.resources.displayMetrics.heightPixels
@@ -61,21 +55,21 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         viewModel.setCurrentPage(measuredPage, false)
     }
 
-    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int) {
+    override fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
         fragment.scrollAfterLoading(
-            currentPageInfo.spinePageList[position].height.toInt()
+            pageInfo.spinePageList[position].height.toInt()
         )
     }
 
-    override fun onPagerItemSelected(viewModel: ReaderViewModel, pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
+    override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         val currentFragment = adapter.getFragmentAt(position)
-        subscribeScroll(currentFragment, pager, viewModel)
+        subscribeScroll(currentFragment, pager)
 
-        if (lastSpineIndex == position + 1) onScrollToPrevPagerItem(currentFragment, viewModel.getCurrentPageInfo(), position)
+        if (lastSpineIndex == position + 1) onScrollToPrevPagerItem(currentFragment, position)
         lastSpineIndex = position
     }
     
-    private fun subscribeScroll(fragment: WebContainerFragment, pager: VerticalViewPager, viewModel: ReaderViewModel) {
+    private fun subscribeScroll(fragment: WebContainerFragment, pager: VerticalViewPager) {
         lastScrollDisposables.clear()
 
         fragment
@@ -96,7 +90,6 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
             .subscribe { scrollPosition ->
                 onWebViewScrolled(
                     pager,
-                    viewModel,
                     scrollPosition
                 )
             }.let { lastScrollDisposables.add(it) }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -9,7 +9,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.ScrollStatus
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-class ScrollTypeStrategy : ViewerTypeStrategy {
+class ScrollTypeStrategy : ViewerTypeStrategy() {
 
     private val lastScrollDisposables by lazy { CompositeDisposable() }
     private var lastSpineIndex = -1

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -9,7 +9,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.ScrollStatus
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-class ScrollTypeStrategy : ViewerTypeStrategy() {
+class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewModel) {
 
     private val lastScrollDisposables by lazy { CompositeDisposable() }
     private var lastSpineIndex = -1

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -2,6 +2,8 @@ package net.jspiner.epub_viewer.ui.reader.strategy
 
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import net.jspiner.epub_viewer.dto.LoadData
+import net.jspiner.epub_viewer.dto.LoadType
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.ScrollStatus
@@ -51,7 +53,13 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         if (lastSpineIndex == position + 1) onScrollToPrevPagerItem(currentFragment, position)
         lastSpineIndex = position
 
-        viewModel.setSpineItem(viewModel.extractedEpub.opf.spine.itemrefs[position])
+        val itemRef = viewModel.extractedEpub.opf.spine.itemrefs[position]
+        viewModel.setLoadData(
+            LoadData(
+                LoadType.FILE,
+                viewModel.toManifestItem(itemRef)
+            )
+        )
     }
     
     private fun subscribeScroll(fragment: WebContainerFragment, pager: VerticalViewPager) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -8,20 +8,22 @@ import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
 
+    protected val pageInfo: PageInfo
+        get() = viewModel.getCurrentPageInfo()
+
     abstract fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 
-    abstract fun getAllPageCount(pageInfo: PageInfo): Int
+    abstract fun getAllPageCount(): Int
 
     abstract fun setCurrentPagerItem(
         pager: VerticalViewPager,
         adapter: EpubPagerAdapter,
-        pageInfo: PageInfo,
         currentPage: Int
     )
 
-    abstract fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
+    abstract fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int)
 
-    abstract fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int)
+    abstract fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int)
 
-    abstract fun onPagerItemSelected(viewModel: ReaderViewModel, pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
+    abstract fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -4,6 +4,7 @@ import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
+import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 interface ViewerTypeStrategy {
 
@@ -19,4 +20,6 @@ interface ViewerTypeStrategy {
     )
 
     fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
+
+    fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,0 +1,5 @@
+package net.jspiner.epub_viewer.ui.reader.strategy
+
+interface ViewerTypeStrategy {
+    
+}

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 interface ViewerTypeStrategy {
@@ -8,5 +9,12 @@ interface ViewerTypeStrategy {
     fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 
     fun getAllPageCount(pageInfo: PageInfo): Int
+
+    fun setCurrentPagerItem(
+        pager: VerticalViewPager,
+        adapter: EpubPagerAdapter,
+        pageInfo: PageInfo,
+        currentPage: Int
+    )
 
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,6 +1,7 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
@@ -17,4 +18,5 @@ interface ViewerTypeStrategy {
         currentPage: Int
     )
 
+    fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,8 +1,11 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
 import net.jspiner.epub_viewer.dto.PageInfo
+import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 
 interface ViewerTypeStrategy {
+
+    fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 
     fun getAllPageCount(pageInfo: PageInfo): Int
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -22,4 +22,6 @@ interface ViewerTypeStrategy {
     fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
 
     fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int)
+
+    fun onPagerItemSelected(viewModel: ReaderViewModel, pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -6,22 +6,22 @@ import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-interface ViewerTypeStrategy {
+abstract class ViewerTypeStrategy {
 
-    fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
+    abstract fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 
-    fun getAllPageCount(pageInfo: PageInfo): Int
+    abstract fun getAllPageCount(pageInfo: PageInfo): Int
 
-    fun setCurrentPagerItem(
+    abstract fun setCurrentPagerItem(
         pager: VerticalViewPager,
         adapter: EpubPagerAdapter,
         pageInfo: PageInfo,
         currentPage: Int
     )
 
-    fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
+    abstract fun onWebViewScrolled(pager: VerticalViewPager, viewModel: ReaderViewModel, scrollPosition: Int)
 
-    fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int)
+    abstract fun onScrollToPrevPagerItem(fragment: WebContainerFragment, currentPageInfo: PageInfo, position: Int)
 
-    fun onPagerItemSelected(viewModel: ReaderViewModel, pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
+    abstract fun onPagerItemSelected(viewModel: ReaderViewModel, pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -6,7 +6,7 @@ import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
 import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
-abstract class ViewerTypeStrategy {
+abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
 
     abstract fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -4,7 +4,6 @@ import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
-import net.jspiner.epub_viewer.ui.reader.viewer.WebContainerFragment
 
 abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
 
@@ -20,10 +19,6 @@ abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
         adapter: EpubPagerAdapter,
         currentPage: Int
     )
-
-    abstract fun onWebViewScrolled(pager: VerticalViewPager, scrollPosition: Int)
-
-    abstract fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int)
 
     abstract fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,5 +1,9 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import net.jspiner.epub_viewer.dto.PageInfo
+
 interface ViewerTypeStrategy {
-    
+
+    fun getAllPageCount(pageInfo: PageInfo): Int
+
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/toolbox/ToolboxView.kt
@@ -105,7 +105,7 @@ class ToolboxView @JvmOverloads constructor(
     }
 
     override fun performClick(): Boolean {
-        val last = viewModel.getToolboxVisible().value!!
+        val last = viewModel.getCurrentToolboxVisible()
         viewModel.setToolboxVisible(!last)
         return super.performClick()
     }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -101,10 +101,7 @@ class EpubView @JvmOverloads constructor(
             }
 
             override fun onPageSelected(position: Int) {
-                viewModel.navigateToIndex(position)
-                viewModel.viewerTypeStrategy.onPagerItemSelected(
-                    binding.verticalViewPager, adapter, position
-                )
+                viewModel.onPagerItemSelected(binding.verticalViewPager, adapter, position)
             }
 
             override fun onPageScrolled(p0: Int, p1: Float, p2: Int) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -150,10 +150,11 @@ class EpubView @JvmOverloads constructor(
             .getScrollPosition()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { scrollPosition ->
-                if (viewModel.getCurrentViewerType() == ViewerType.SCROLL) {
-                    val measuredPage = measureCurrentPage(scrollPosition)
-                    viewModel.setCurrentPage(measuredPage, false)
-                }
+                viewModel.viewerTypeStrategy.onWebViewScrolled(
+                    binding.verticalViewPager,
+                    viewModel,
+                    scrollPosition
+                )
             }.let { lastScrollDisposables.add(it) }
     }
 
@@ -162,25 +163,6 @@ class EpubView @JvmOverloads constructor(
             fragment.scrollAfterLoading(
                 viewModel.getCurrentPageInfo().spinePageList[position].height.toInt()
             )
-        }
-    }
-
-    private fun measureCurrentPage(): Int {
-        val currentFragment = adapter.getFragmentAt(binding.verticalViewPager.currentItem)
-        return measureCurrentPage(currentFragment.getScrollPosition().value ?: 0)
-    }
-
-    private fun measureCurrentPage(scrollPosition: Int): Int {
-        return if (viewModel.getCurrentViewerType() == ViewerType.SCROLL) {
-            val spinePosition = binding.verticalViewPager.currentItem
-            val pageInfo = viewModel.getCurrentPageInfo()
-            val deviceHeight = context.resources.displayMetrics.heightPixels
-
-            val sumUntilPreview = if (spinePosition == 0) 0 else pageInfo.pageCountSumList[spinePosition - 1]
-
-            sumUntilPreview + (scrollPosition / deviceHeight)
-        } else {
-            binding.verticalViewPager.currentItem
         }
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -123,7 +123,7 @@ class EpubView @JvmOverloads constructor(
         val currentFragment = adapter.getFragmentAt(position)
         subscribeScroll(currentFragment)
 
-        if (lastSpineIndex == position + 1) onScrollToPrevSpine(currentFragment, position)
+        if (lastSpineIndex == position + 1) onScrollToPrevPagerItem(currentFragment, position)
         lastSpineIndex = position
     }
 
@@ -158,11 +158,11 @@ class EpubView @JvmOverloads constructor(
             }.let { lastScrollDisposables.add(it) }
     }
 
-    private fun onScrollToPrevSpine(fragment: WebContainerFragment, position: Int) {
-        if (viewModel.getCurrentViewerType() == ViewerType.SCROLL) {
-            fragment.scrollAfterLoading(
-                viewModel.getCurrentPageInfo().spinePageList[position].height.toInt()
-            )
-        }
+    private fun onScrollToPrevPagerItem(fragment: WebContainerFragment, position: Int) {
+        viewModel.viewerTypeStrategy.onScrollToPrevPagerItem(
+            fragment,
+            viewModel.getCurrentPageInfo(),
+            position
+        )
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -7,7 +7,6 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
 import net.jspiner.epub_viewer.R
 import net.jspiner.epub_viewer.databinding.ViewEpubViewerBinding
@@ -62,8 +61,8 @@ class EpubView @JvmOverloads constructor(
             BiFunction { pageInfo: PageInfo, _: ViewerType -> pageInfo }
         ).observeOn(AndroidSchedulers.mainThread())
             .compose(bindLifecycle())
-            .subscribe { pageInfo ->
-                val pageCount = viewModel.viewerTypeStrategy.getAllPageCount(pageInfo)
+            .subscribe {
+                val pageCount = viewModel.viewerTypeStrategy.getAllPageCount()
                 adapter.setAllPageCount(pageCount)
                 binding.verticalViewPager.currentItem = 0
             }
@@ -90,7 +89,6 @@ class EpubView @JvmOverloads constructor(
         viewModel.viewerTypeStrategy.setCurrentPagerItem(
             binding.verticalViewPager,
             adapter,
-            viewModel.getCurrentPageInfo(),
             currentPage
         )
     }
@@ -105,7 +103,7 @@ class EpubView @JvmOverloads constructor(
             override fun onPageSelected(position: Int) {
                 viewModel.navigateToIndex(position)
                 viewModel.viewerTypeStrategy.onPagerItemSelected(
-                    viewModel, binding.verticalViewPager, adapter, position
+                    binding.verticalViewPager, adapter, position
                 )
             }
 
@@ -113,8 +111,5 @@ class EpubView @JvmOverloads constructor(
                 // no-op
             }
         })
-    }
-
-    private fun onPageSelectedInPageMode(position: Int) {
     }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -61,15 +61,12 @@ class EpubView @JvmOverloads constructor(
         Observable.zip(
             viewModel.getPageInfo(),
             viewModel.getViewerType(),
-            BiFunction { _: PageInfo, t2: ViewerType -> t2 }
+            BiFunction { pageInfo: PageInfo, _: ViewerType -> pageInfo }
         ).observeOn(AndroidSchedulers.mainThread())
             .compose(bindLifecycle())
-            .subscribe { viewerType ->
-                val pageInfo = viewModel.getCurrentPageInfo()
-                when (viewerType) {
-                    ViewerType.SCROLL -> adapter.setAllPageCount(pageInfo.spinePageList.size)
-                    ViewerType.PAGE -> adapter.setAllPageCount(pageInfo.allPage)
-                }
+            .subscribe { pageInfo ->
+                val pageCount = viewModel.viewerTypeStrategy.getAllPageCount(pageInfo)
+                adapter.setAllPageCount(pageCount)
                 binding.verticalViewPager.currentItem = 0
             }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -74,10 +74,7 @@ class EpubView @JvmOverloads constructor(
             .observeOn(AndroidSchedulers.mainThread())
             .compose(bindLifecycle())
             .subscribe {
-                when (it!!) {
-                    ViewerType.SCROLL -> binding.verticalViewPager.verticalMode()
-                    ViewerType.PAGE -> binding.verticalViewPager.horizontalMode()
-                }
+                viewModel.viewerTypeStrategy.changeViewPagerOrientation(binding.verticalViewPager)
             }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -10,11 +10,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.BiFunction
 import net.jspiner.epub_viewer.R
 import net.jspiner.epub_viewer.databinding.ViewEpubViewerBinding
+import net.jspiner.epub_viewer.dto.LoadData
 import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.dto.ViewerType
 import net.jspiner.epub_viewer.ui.base.BaseView
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
-import java.io.File
 
 class EpubView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
@@ -37,16 +37,10 @@ class EpubView @JvmOverloads constructor(
     override fun dispatchTouchEvent(ev: MotionEvent?) = true
 
     private fun subscribe() {
-        viewModel.getCurrentSpineItem()
-            .map { viewModel.toManifestItem(it) }
+        viewModel.getLoadData()
             .observeOn(AndroidSchedulers.mainThread())
             .compose(bindLifecycle())
-            .subscribe { setSpineFile(it) }
-
-        viewModel.getRawData()
-            .observeOn(AndroidSchedulers.mainThread())
-            .compose(bindLifecycle())
-            .subscribe { setRawData(it.first.toURI().toURL().toString(), it.second) }
+            .subscribe { setLoadData(it) }
 
         viewModel.getCurrentPage()
             .filter { it.second } // needUpdate
@@ -81,14 +75,9 @@ class EpubView @JvmOverloads constructor(
             }
     }
 
-    private fun setSpineFile(file: File) {
+    private fun setLoadData(loadData: LoadData) {
         val currentPosition = binding.verticalViewPager.currentItem
-        adapter.getFragmentAt(currentPosition).loadFile(file)
-    }
-
-    private fun setRawData(baseUrl: String, string: String) {
-        val currentPosition = binding.verticalViewPager.currentItem
-        adapter.getFragmentAt(currentPosition).loadData(baseUrl, string)
+        adapter.getFragmentAt(currentPosition).loadData(loadData)
     }
 
     private fun setCurrentPage(currentPage: Int) {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -89,41 +89,12 @@ class EpubView @JvmOverloads constructor(
     }
 
     private fun setCurrentPage(currentPage: Int) {
-        when (viewModel.getCurrentViewerType()!!) {
-            ViewerType.SCROLL -> setCurrentPageInScrollMode(currentPage)
-            ViewerType.PAGE -> setCurrentPageInPageMode(currentPage)
-        }
-    }
-
-    private fun setCurrentPageInScrollMode(currentPage: Int) {
-        if (measureCurrentPage() == currentPage) return
-
-        fun getScrollPosition(index: Int): Int {
-            val deviceHeight = context.resources.displayMetrics.heightPixels
-
-            return if (index == 0) {
-                0
-            } else {
-                (currentPage - viewModel.getCurrentPageInfo().pageCountSumList[index - 1]) * deviceHeight
-            }
-        }
-
-        var spineIndex = -1
-        var scrollPosition = 0
-        for ((i, pageSum) in viewModel.getCurrentPageInfo().pageCountSumList.withIndex()) {
-            if (currentPage + 1 <= pageSum) {
-                spineIndex = i
-                scrollPosition = getScrollPosition(i)
-                break
-            }
-        }
-
-        binding.verticalViewPager.currentItem = spineIndex
-        adapter.getFragmentAt(spineIndex).scrollAfterLoading(scrollPosition)
-    }
-
-    private fun setCurrentPageInPageMode(currentPage: Int) {
-        binding.verticalViewPager.currentItem = currentPage
+        viewModel.viewerTypeStrategy.setCurrentPagerItem(
+            binding.verticalViewPager,
+            adapter,
+            viewModel.getCurrentPageInfo(),
+            currentPage
+        )
     }
 
     private fun initPager() {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -65,6 +65,12 @@ class EpubView @JvmOverloads constructor(
                 val pageCount = viewModel.viewerTypeStrategy.getAllPageCount()
                 adapter.setAllPageCount(pageCount)
                 binding.verticalViewPager.currentItem = 0
+
+                viewModel.onPagerItemSelected(
+                    binding.verticalViewPager,
+                    adapter,
+                    0
+                )
             }
 
         viewModel.getViewerType()

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
@@ -8,6 +8,8 @@ import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 import net.jspiner.epub_viewer.R
 import net.jspiner.epub_viewer.databinding.FragmentWebContainerBinding
+import net.jspiner.epub_viewer.dto.LoadData
+import net.jspiner.epub_viewer.dto.LoadType
 import net.jspiner.epub_viewer.ui.base.BaseFragment
 import net.jspiner.epub_viewer.ui.base.EpubWebClient
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
@@ -77,14 +79,21 @@ class WebContainerFragment : BaseFragment<FragmentWebContainerBinding, ReaderVie
 
     fun getScrollPosition() = scrollPositionSubject
 
-    fun loadFile(file: File) {
+    fun loadData(loadData: LoadData) {
+        when(loadData.loadType) {
+            LoadType.RAW -> loadRawData(loadData.file, loadData.rawData!!)
+            LoadType.FILE -> loadFile(loadData.file)
+        }
+    }
+
+    private fun loadFile(file: File) {
         binding.webView.loadUrl(file.toURI().toURL().toString())
         binding.loadingView.visibility = VISIBLE
     }
 
-    fun loadData(baseUrl: String, rawString: String) {
+    private fun loadRawData(file: File, rawString: String) {
         binding.webView.loadDataWithBaseURL(
-            baseUrl,
+            file.toURI().toURL().toString(),
             rawString,
             null,
             "utf-8",


### PR DESCRIPTION
## 개요
- viewModel 코드를 정리하고, viewerType별로 분기되는 코드들을 분리하였습니다.

## 작업내용
- viewerType별로 다른구현이 필요한 부분들을 `PageTypeStrategy` `ScrollTypeStrategy`로 분리하였습니다.
- viewModel 코드를 정리하였습니다.
- `LoadData` 타입을 지정해 `rawData`와 `Spine`으로 나누어 emit하던 subject를 통합하였습니다.