### PR TITLE
보기방식 변경시 보던위치 유지

### DIFF
--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -126,6 +126,7 @@ class ReaderViewModel : BaseViewModel() {
     fun setViewerType(viewerType: ViewerType) {
         viewerTypeSubject.onNext(viewerType)
 
+        viewerTypeStrategy.unSubscribe()
         viewerTypeStrategy = when(viewerType) {
             ViewerType.SCROLL -> ScrollTypeStrategy(this)
             ViewerType.PAGE -> PageTypeStrategy(this)

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderViewModel.kt
@@ -31,9 +31,11 @@ class ReaderViewModel : BaseViewModel() {
 
     private val loadDataSubject: PublishSubject<LoadData> = PublishSubject.create()
     private val toolboxShowSubject: BehaviorSubject<Boolean> = BehaviorSubject.createDefault(true)
-    private val pageSubject: PublishSubject<Pair<Int, Boolean>> = PublishSubject.create()
+    private val pageSubject: BehaviorSubject<Pair<Int, Boolean>> = BehaviorSubject.create()
     private val viewerTypeSubject = BehaviorSubject.createDefault(ViewerType.SCROLL)
     private val pageInfoSubject = BehaviorSubject.create<PageInfo>()
+
+    private var lastSavePoint = 0f
 
     fun setEpubFile(file: File) {
         this.file = file
@@ -112,7 +114,8 @@ class ReaderViewModel : BaseViewModel() {
 
     fun setPageInfo(pageInfo: PageInfo) {
         pageInfoSubject.onNext(pageInfo)
-        pageSubject.onNext(0 to false)
+        val lastSavePage = (pageInfo.allPage * lastSavePoint).toInt()
+        pageSubject.onNext(lastSavePage to true)
     }
 
     fun getPageInfo(): Observable<PageInfo> = pageInfoSubject
@@ -124,16 +127,21 @@ class ReaderViewModel : BaseViewModel() {
     fun getViewerType(): Observable<ViewerType> = viewerTypeSubject
     fun getCurrentViewerType() = viewerTypeSubject.value
     fun setViewerType(viewerType: ViewerType) {
-        viewerTypeSubject.onNext(viewerType)
+        saveLastPosition()
 
         viewerTypeStrategy.unSubscribe()
         viewerTypeStrategy = when(viewerType) {
             ViewerType.SCROLL -> ScrollTypeStrategy(this)
             ViewerType.PAGE -> PageTypeStrategy(this)
         }
+        viewerTypeSubject.onNext(viewerType)
     }
 
     fun getLoadData(): Observable<LoadData> = loadDataSubject
     fun setLoadData(loadData: LoadData) = loadDataSubject.onNext(loadData)
 
+    private fun saveLastPosition() {
+        val lastPage = pageSubject.value!!.first
+        lastSavePoint = lastPage / getCurrentPageInfo().allPage.toFloat()
+    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -13,6 +13,7 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
 
     override fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager) {
         verticalViewPager.horizontalMode()
+        verticalViewPager.enableScroll()
     }
 
     override fun getAllPageCount(): Int = pageInfo.allPage

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ScrollTypeStrategy.kt
@@ -68,6 +68,7 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         fragment
             .getScrollState()
             .distinctUntilChanged()
+            .compose(bindToLifecycle())
             .subscribe { scrollStatus ->
                 when (scrollStatus) {
                     ScrollStatus.REACHED_TOP -> pager.enableScroll()
@@ -80,6 +81,7 @@ class ScrollTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMo
         fragment
             .getScrollPosition()
             .observeOn(AndroidSchedulers.mainThread())
+            .compose(bindToLifecycle())
             .subscribe { scrollPosition ->
                 onWebViewScrolled(
                     pager,

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/ViewerTypeStrategy.kt
@@ -1,14 +1,17 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import io.reactivex.subjects.CompletableSubject
 import net.jspiner.epub_viewer.dto.PageInfo
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
 import net.jspiner.epub_viewer.ui.reader.viewer.EpubPagerAdapter
 import net.jspiner.epub_viewer.ui.reader.viewer.VerticalViewPager
+import net.jspiner.epub_viewer.util.LifecycleTransformer
 
 abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
 
     protected val pageInfo: PageInfo
         get() = viewModel.getCurrentPageInfo()
+    private val lifecycleSubject: CompletableSubject  = CompletableSubject.create()
 
     abstract fun changeViewPagerOrientation(verticalViewPager: VerticalViewPager)
 
@@ -21,4 +24,12 @@ abstract class ViewerTypeStrategy(protected val viewModel: ReaderViewModel) {
     )
 
     abstract fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int)
+
+    protected fun <T> bindToLifecycle(): LifecycleTransformer<T> {
+        return LifecycleTransformer(lifecycleSubject)
+    }
+
+    fun unSubscribe() {
+        lifecycleSubject.onComplete()
+    }
 }

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/WebContainerFragment.kt
@@ -44,7 +44,7 @@ class WebContainerFragment : BaseFragment<FragmentWebContainerBinding, ReaderVie
         binding.webView.let { webView ->
             fun getContentHeight() = (webView.contentHeight * resources.displayMetrics.density.toDouble()).toInt()
             fun updateScrollState() {
-                if (!epubWebClient.isPageFinished || epubWebClient.scrollPositionAfterLoading != 0) return
+                if (context == null || !epubWebClient.isPageFinished || epubWebClient.scrollPositionAfterLoading != 0) return
 
                 val height = getContentHeight()
                 val webViewHeight = webView.measuredHeight


### PR DESCRIPTION
## 개요
- 보기방식을 전환할때 이전에 보던위치를 유지시키는 기능 추가

## 작업내용
- 비율로 이전에 보던 내용을 계산해 viewerType이 바뀐후 page를 유지시켰습니다.
- fragment 내에서 context가 간혹 null로 나오는 버그 수정했습니다. a4a3ee7196eccabc27151a0869e990aa724e430c