### PR TITLE
넘겨보기방식(페이지) 버벅임 수정

### DIFF
--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/strategy/PageTypeStrategy.kt
@@ -1,5 +1,8 @@
 package net.jspiner.epub_viewer.ui.reader.strategy
 
+import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import net.jspiner.epub_viewer.dto.LoadData
 import net.jspiner.epub_viewer.dto.LoadType
 import net.jspiner.epub_viewer.ui.reader.ReaderViewModel
@@ -24,37 +27,45 @@ class PageTypeStrategy(viewModel: ReaderViewModel) : ViewerTypeStrategy(viewMode
     override fun onPagerItemSelected(pager: VerticalViewPager, adapter: EpubPagerAdapter, position: Int) {
         viewModel.setCurrentPage(position, false)
 
-        sendRawFile(position)
+        readRawData(position)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { loadData ->
+                viewModel.setLoadData(loadData)
+            }
     }
 
-    private fun sendRawFile(index: Int) {
-        var currentSpineIndex = -1
-        for ((i, sumUntil) in pageInfo.pageCountSumList.withIndex()) {
-            currentSpineIndex = i
-            if (index < sumUntil) break
-        }
+    private fun readRawData(index: Int): Single<LoadData> {
+        return Single.create<LoadData> { emitter ->
+            var currentSpineIndex = -1
+            for ((i, sumUntil) in pageInfo.pageCountSumList.withIndex()) {
+                currentSpineIndex = i
+                if (index < sumUntil) break
+            }
 
-        val originFile = viewModel.toManifestItem(viewModel.extractedEpub.opf.spine.itemrefs[currentSpineIndex])
-        val rawString = readFile(originFile)
-        val bodyStart = rawString.indexOf("<body>") + "<body>".length
-        val bodyEnd = rawString.indexOf("</body")
+            val originFile = viewModel.toManifestItem(viewModel.extractedEpub.opf.spine.itemrefs[currentSpineIndex])
+            val rawString = readFile(originFile)
+            val bodyStart = rawString.indexOf("<body>") + "<body>".length
+            val bodyEnd = rawString.indexOf("</body")
 
-        val emptyHtml = rawString.substring(0, bodyStart) + "%s" + rawString.substring(bodyEnd)
-        val body = rawString.substring(bodyStart, bodyEnd)
+            val emptyHtml = rawString.substring(0, bodyStart) + "%s" + rawString.substring(bodyEnd)
+            val body = rawString.substring(bodyStart, bodyEnd)
 
-        val innerPageIndex = index - if (currentSpineIndex == 0) 0 else pageInfo.pageCountSumList[currentSpineIndex - 1]
-        val splitIndexList = pageInfo.spinePageList[currentSpineIndex].splitIndexList
-        val splitStart = if (innerPageIndex == 0) 0 else splitIndexList[innerPageIndex - 1].toInt()
-        val splitEnd = splitIndexList[innerPageIndex].toInt()
-        val splitedText = body.split(" ").subList(splitStart, splitEnd).joinToString(" ")
-        val res = String.format(emptyHtml, splitedText)
-        viewModel.setLoadData(
-            LoadData(
-                LoadType.RAW,
-                originFile,
-                res
+            val innerPageIndex = index - if (currentSpineIndex == 0) 0 else pageInfo.pageCountSumList[currentSpineIndex - 1]
+            val splitIndexList = pageInfo.spinePageList[currentSpineIndex].splitIndexList
+            val splitStart = if (innerPageIndex == 0) 0 else splitIndexList[innerPageIndex - 1].toInt()
+            val splitEnd = splitIndexList[innerPageIndex].toInt()
+            val splitedText = body.split(" ").subList(splitStart, splitEnd).joinToString(" ")
+            val res = String.format(emptyHtml, splitedText)
+
+            emitter.onSuccess(
+                LoadData(
+                    LoadType.RAW,
+                    originFile,
+                    res
+                )
             )
-        )
+        }
     }
 
     private fun readFile(file: File): String {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/viewer/EpubView.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.BiFunction
+import io.reactivex.schedulers.Schedulers
 import net.jspiner.epub_viewer.R
 import net.jspiner.epub_viewer.databinding.ViewEpubViewerBinding
 import net.jspiner.epub_viewer.dto.LoadData
@@ -38,6 +39,7 @@ class EpubView @JvmOverloads constructor(
 
     private fun subscribe() {
         viewModel.getLoadData()
+            .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .compose(bindLifecycle())
             .subscribe { setLoadData(it) }


### PR DESCRIPTION
## 개요
- 넘겨보기방식(페이지) 에서만 발생하는 프리징(버벅임) 수정

## 원인
- 페이지 보기 방식에서는 file io가 빈번히 일어나는데, 해당 작업이 ui thread에서 처리되고 있었음.

## 가능한 해결방안
- 캐싱도입 -> #20 참고
- file io를 타 thread에서 처리 -> 적용됨

## 작업내용
- file io작업은 `Schedulers.io`를 통해 io thread에서 작업하고 결과만 ui thread에서 처리하도록 변경

## 기타
- *쓰레드 변경*, *함수명 변경* 외 논리적 변경은 없습니다.