### PR TITLE
파일 읽기/쓰기 권한 요청위치 변경

### DIFF
--- a/app/src/main/java/net/jspiner/epub_viewer/ui/library/LibraryViewHolder.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/library/LibraryViewHolder.kt
@@ -5,7 +5,7 @@ import com.bumptech.glide.Glide
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import net.jspiner.epub_viewer.databinding.ItemLibraryBinding
-import net.jspiner.epub_viewer.ui.reader.startReaderActivity
+import net.jspiner.epub_viewer.ui.reader.ReaderActivity
 import net.jspiner.epubstream.EpubStream
 import java.io.File
 
@@ -16,7 +16,7 @@ class LibraryViewHolder(val binding: ItemLibraryBinding) : RecyclerView.ViewHold
 
     init {
         binding.root.setOnClickListener {
-            startReaderActivity(getContext(), File(epubPath))
+            ReaderActivity.startActivity(getContext(), File(epubPath))
         }
     }
 

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -1,12 +1,9 @@
 package net.jspiner.epub_viewer.ui.reader
 
-import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import com.gun0912.tedpermission.PermissionListener
-import com.gun0912.tedpermission.TedPermission
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import net.jspiner.epub_viewer.R
@@ -56,7 +53,6 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
         initViews()
 
         viewModel.setEpubFile(epubFile)
-        requestPermission()
         viewModel.getViewerType()
             .skip(1)
             .compose(bindLifecycle())
@@ -66,20 +62,6 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
     private fun initViews() {
         binding.toolboxView.touchSender = { binding.epubView.sendTouchEvent(it) }
         setNavigationBarColor(R.color.colorPrimaryDark)
-    }
-
-    private fun requestPermission() {
-        TedPermission.with(this)
-            .setPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
-            .setPermissionListener(object : PermissionListener {
-                override fun onPermissionGranted() {
-                    loadEpub()
-                }
-
-                override fun onPermissionDenied(list: MutableList<String>?) {
-                    requestPermission()
-                }
-            }).check()
     }
 
     private fun loadEpub() {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -57,6 +57,8 @@ class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
             .skip(1)
             .compose(bindLifecycle())
             .subscribe { calculatePage() }
+
+        loadEpub()
     }
 
     private fun initViews() {

--- a/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/net/jspiner/epub_viewer/ui/reader/ReaderActivity.kt
@@ -21,16 +21,19 @@ import net.jspiner.epub_viewer.ui.etc.EtcActivity
 import net.jspiner.epub_viewer.ui.search.SearchActivity
 import java.io.File
 
-const val INTENT_KEY_FILE = "intentKeyFile"
-
-fun startReaderActivity(context: Context, epubFile: File) {
-    val intent = Intent(context, ReaderActivity::class.java)
-    intent.putExtra(INTENT_KEY_FILE, epubFile)
-    context.startActivity(intent)
-}
-
 class ReaderActivity : BaseActivity<ActivityReaderBinding, ReaderViewModel>() {
 
+    companion object {
+
+        const val INTENT_KEY_FILE = "intentKeyFile"
+
+        fun startActivity(context: Context, epubFile: File) {
+            val intent = Intent(context, ReaderActivity::class.java)
+            intent.putExtra(INTENT_KEY_FILE, epubFile)
+            context.startActivity(intent)
+        }
+
+    }
     override fun getLayoutId() = R.layout.activity_reader
     override fun createViewModel() = ReaderViewModel()
 


### PR DESCRIPTION
## 개요
- '내서재' 가 개발되기전 임시로 뷰어에서 권한을 요청했으나, 이제 '내서재'에서 권한이 필요해 권한요청위치를 '내서재' 실행시점으로 변경

## 작업내용
- '파일 읽기/쓰기' 권한을 요청하는곳을 `ReaderActivity'에서 'LibraryActivity'로 이동하였습니다.

## 기타
- companion object가 적용되어 있지 않은곳도 함께 수정함 bc0b0f04235edd22bede7b2b7478b52395a32e65